### PR TITLE
fix: Move get_it to public dependencies since it prevents using the package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,9 @@ publish_to: none
 environment:
   sdk: '>=2.13.0 <3.0.0'
 
-
-dev_dependencies:
   # Dependency Injection
   get_it: ^7.1.3
 
+dev_dependencies:
   # Linting and Code analysis
   effective_dart: ^1.3.1


### PR DESCRIPTION
## Description
With `get_it` in _dev_dependencies_, the package can't be imported in other package because it causes resolving issues.