### PR TITLE
chore: update get_it and dart_lint_rules dependencies

### DIFF
--- a/lib/src/dependencies_manager.dart
+++ b/lib/src/dependencies_manager.dart
@@ -1,6 +1,7 @@
 import 'package:dart_dependencies_manager/src/exceptions.dart';
 import 'package:get_it/get_it.dart';
 
+/// The signature for the factory function for register a dependency.
 typedef DependencyFactory<T extends Object> = Future<T> Function();
 
 /// Manages all the dependencies of the applications.

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,6 +1,10 @@
+/// The exception thrown when a dependency is not found during a request to
+/// retrieve it.
 class DependencyNotFoundException implements Exception {
+  /// The error message.
   final String message;
 
+  /// Creates a [DependencyNotFoundException] with an associated error [message].
   DependencyNotFoundException({required final this.message});
 
   String get _parsedGetItAssertionErrorMessage {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   # Dependency Injection
-  get_it: ^7.1.3
+  get_it: ^7.1.4
 
 dev_dependencies:
   # Linting and Code analysis

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,4 @@ dev_dependencies:
   dart_lint_rules:
     git:
       url: git@github.com:fabriziocacicia/dart_lint_rules.git
-      ref: v0.0.1
+      ref: v0.0.2


### PR DESCRIPTION
## Description

- Update `get_it` to version 7.1.4
- Update `dart_lint_rules` to version 0.0.2 and fix the new analyzer warning that it caused